### PR TITLE
Abstract RapidAPI hostname to more easily handle name changes

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -1,6 +1,12 @@
-# api key to use for https://rapidapi.com/apidojo/api/yahoo-finance1
+# API key for RapidAPI https://rapidapi.com/apidojo/api/yahoo-finance1
 rapidapiKey: mYsUp3rs3CretKEY12345
+# API key for CoinAPI (https://www.coinapi.io/)
 coinapiioKey: mYsUp3rs3CretKEY12345
 
+# Triggers
 stocktrigger: stonks
 cryptotrigger: hodl
+
+# Hostname header RapidAPI expects
+rapidapiHost: yh-finance.p.rapidapi.com
+

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.1.0
 id: org.jobmachine.tickerbot
-version: 0.0.5
+version: 0.0.6
 license: MIT
 modules:
 - tickerbot

--- a/tickerbot.py
+++ b/tickerbot.py
@@ -15,6 +15,7 @@ class Config(BaseProxyConfig):
         helper.copy("coinapiioKey")
         helper.copy("stocktrigger")
         helper.copy("cryptotrigger")
+        helper.copy("rapidapiHost")
 
 class TickerBot(Plugin):
     async def start(self) -> None:
@@ -39,10 +40,10 @@ class TickerBot(Plugin):
             return None
 
         tickerUpper = ticker.upper()
-        url = f"https://apidojo-yahoo-finance-v1.p.rapidapi.com/market/v2/get-quotes?symbols={tickerUpper}"
+        url = f'https://{self.config["rapidapiHost"]}/market/v2/get-quotes?symbols={tickerUpper}'
         headers = {
             'x-rapidapi-key': self.config["rapidapiKey"],
-            'x-rapidapi-host': "apidojo-yahoo-finance-v1.p.rapidapi.com"
+            'x-rapidapi-host': self.config["rapidapiHost"]
             }
         
         try:


### PR DESCRIPTION
Stock quotes were not working, presumably because RapidAPI changed a portion of the endpoint.  Moving the hostname to a variable allows for users to adjust without requiring a re-release.